### PR TITLE
Admit asterisk in Quantity

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -129,7 +129,7 @@ integral := [0-9]+
 Quantity := mantissa uncertainty? magnitude? symbol
 mantissa := [0-9]+([.][0-9]+)?
 uncertainty := ("±" | "+/-") [0-9]+([.][0-9]+)?
-magnitude := "x" "10^" [0-9]+ | "×" "10" [⁰⁻⁹]
+magnitude := ("x" | "*" | "×") "10" ( "^" [0-9]+ | [⁰⁻⁹] )
 symbol := [a-zA-Z/°]+
 
 Scope := step_block | code_block | Attribute | section_chunk | response_block


### PR DESCRIPTION
The point of having both a fancy Unicode representation for Quantity and a pragmatic ASCII one is that mostly people are just going to type ASCII characters on their keyboard. Sure, Unicode is cute when formatted but no one is going to write that way.

Since people are used to writing `*` for multiplication in programming code, we really ought to just support that when specifying magnitude of a Quantity. Almost silly that we allow `x`. We won't remove that, it's fine, and anyone reading the documentation seeing `×` will probably not realize its not `x` anyway.

These are now all supported:

```
4.2 × 10⁹ years
4.2 x 10^9 years
4.2 * 10^9 years
```