### PR TITLE
Define PFFTT for use in running Technique documents

### DIFF
--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -56,11 +56,19 @@ Identifier := [a-z][a-z0-9_]*
 
 uri := ("https://" | "file:///") [a-zA-Z0-9.,?&#%=:/+-~_]+
 
-Path :=
-    absolute
-    relative
+; the "fully qualified" path of a step. There are implicit nodes (when no
+; top-level procedure is defined, for example, and for the case where actions
+; are defined in the description of a procedure). The following are all valid
+; paths:
+;
+; /
+; /2
+; /2/a/-1
+; /local_network:
+; /local_network:2
+; /local_network:2/a/-1
 
-absolute := "/"
+Path := "/" procedure? ( component ( "/" component )* )?
 
 relative := procedure? component ( "/" component )*
 

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -1,0 +1,110 @@
+; A grammar for the Procedure interchange Format For Transferring Techniques.
+; This format is carefully defined to simplify parsing. Whitespace only
+; appears when defined.
+;
+; This is written in the style of a Backus–Naur Form with a few augmentations.
+; When specified, character classes are in the style of those accepted by
+; regular expressions, such as [a-z]. Explicitly required characters such as
+; spaces are marked with [ ]; a [.] represents a period and not any character.
+; Otherwise special characters in regular expressions are not shown escaped.
+;
+; The convention adopted here is that names that represent actual types in the
+; abstract syntax tree are in Proper Case whereas other definitions (often
+; representing variants in enumerations in the implementation) are written in
+; snake_case.
+
+NEWLINE := "\n" | "\r\n"
+
+; A single space character is the separator between fields
+SPACE := " "
+
+; Specially defined as any characters but matching lazily, such that whatever
+; token or pattern that follows is excluded.
+ANY
+
+; A PFFTT file is a series of record lines.
+
+File := Record*
+
+Record :=
+    Timestamp
+    SPACE
+    Path
+    SPACE
+    State
+    NEWLINE
+
+; ISO 8601 timestamp
+Timestamp := year '-' month '-' day 'T' hour ':' minute ':' second ('.' fraction)? 'Z'
+
+year := [12][0-9][0-9][0-9]
+month := [0-1][0-9]
+day := [0-9][0-9]
+
+hour := [0-2][0-9]
+minute := [0-5][0-9]
+second := [0-5][0-9]
+
+; Optional fractions of a second can be to arbitrary precision, but in
+; practice this is either milliseconds (three digits) or nanoseconds (nine
+; digits).
+fraction := [0-9]*
+
+Identifier := [a-z][a-z0-9_]*
+
+uri := ("https://" | "file:///") [a-zA-Z0-9.,?&#%=:/+-~_]+
+
+Path :=
+    absolute
+    relative
+
+absolute := "/"
+
+relative := procedure? component ( "/" component )*
+
+component := section | step | substep | subsubstep | attribute | invocation | execution
+
+section := [IVX]+
+
+step := dependent_step | parallel_step
+dependent_step := [1-9][0-9]*
+parallel_step := [-]([0-9]|[1-9][0-9])
+
+substep := dependent_substep | parallel_substep
+dependent_substep := [a-hj-km-uwyz]
+parallel_substep := [-]([0-9]|[1-9][0-9])
+
+subsubstep := dependent_subsubstep | parallel_subsubstep
+dependent_subsubstep := [ivxl]+
+parallel_subsubstep := [-]([0-9]|[1-9][0-9])
+
+attribute := role_attribute | place_attribute
+role_attribute := "@" Identifier | "@*"
+place_attribute := "^" Identifier | "^*"
+
+invocation := procedure | uri
+procedure := Identifier ":"
+
+execution :=  Identifier "()"
+
+; Activity verbs and payloads, collectively the event being observed. Done is
+; the most important, recording an outcome of a step.
+
+State :=
+    "Start" SPACE uri run_id |
+    "Pause" |
+    "Resume" SPACE run_id |
+    "Done" SPACE Value |
+    "Skip" |
+    "Fail" (SPACE Value)?
+
+run_id := ":" [0-9]+
+
+Value := unit | tablet
+
+unit := "()"
+
+; The Tablet data structure in Technique can nest arbitrarily but this runs
+; to end of line so any content here is acceptable.
+
+tablet := "[" ANY "]"

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -70,9 +70,9 @@ uri := ("https://" | "file:///") [a-zA-Z0-9.,?&#%=:/+-~_]+
 
 Path := "/" procedure? ( component ( "/" component )* )?
 
-relative := procedure? component ( "/" component )*
+procedure := Identifier ":"
 
-component := section | step | substep | subsubstep | attribute | invocation | execution
+component := section | step | substep | subsubstep | attribute
 
 section := [IVX]+
 
@@ -92,23 +92,27 @@ attribute := role_attribute | place_attribute
 role_attribute := "@" Identifier | "@*"
 place_attribute := "^" Identifier | "^*"
 
-invocation := procedure | uri
-procedure := Identifier ":"
-
-execution :=  Identifier "()"
-
 ; Activity verbs and payloads, collectively the event being observed. Done is
-; the most important, recording an outcome of a step.
+; the most important, recording an outcome of a step. Invoke marks dispatch
+; from the current procedure into another (the return is implicit — the next
+; event's Path reveals the resumed procedure). Execute records a function
+; call out to the host environment.
 
 State :=
     "Start" SPACE uri |
     "Pause" |
     "Resume" |
+    "Invoke" SPACE invocable |
+    "Execute" SPACE executable |
     "Done" SPACE Value |
     "Skip" |
     "Fail" (SPACE Value)?
 
 RunId := [0-9]+
+
+invocable := procedure | uri
+
+executable :=  Identifier "()"
 
 Value := unit | tablet
 

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -9,7 +9,7 @@
 ; Otherwise special characters in regular expressions are not shown escaped.
 ;
 ; The convention adopted here is that names that represent actual types in the
-; abstract syntax tree are in Proper Case whereas other definitions (often
+; parser are in Proper Case whereas other definitions (often
 ; representing variants in enumerations in the implementation) are written in
 ; snake_case.
 
@@ -28,6 +28,8 @@ File := Record*
 
 Record :=
     Timestamp
+    SPACE
+    RunId
     SPACE
     Path
     SPACE
@@ -91,14 +93,14 @@ execution :=  Identifier "()"
 ; the most important, recording an outcome of a step.
 
 State :=
-    "Start" SPACE uri run_id |
+    "Start" SPACE uri |
     "Pause" |
-    "Resume" SPACE run_id |
+    "Resume" |
     "Done" SPACE Value |
     "Skip" |
     "Fail" (SPACE Value)?
 
-run_id := ":" [0-9]+
+RunId := [0-9]+
 
 Value := unit | tablet
 

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -93,10 +93,12 @@ role_attribute := "@" Identifier | "@*"
 place_attribute := "^" Identifier | "^*"
 
 ; Activity verbs and payloads, collectively the event being observed. Done is
-; the most important, recording an outcome of a step. Invoke marks dispatch
-; from the current procedure into another (the return is implicit — the next
-; event's Path reveals the resumed procedure). Execute records a function
-; call out to the host environment.
+; the most important, recording an outcome of a step. Begin marks the start
+; of work on a step (paired with the eventual Done/Skip/Fail); duration is
+; derived from the pair. Invoke marks dispatch from the current procedure
+; into another (the return is implicit — the next event's Path reveals the
+; resumed procedure). Execute records a function call out to the host
+; environment.
 
 State :=
     "Start" SPACE uri |
@@ -104,6 +106,7 @@ State :=
     "Resume" |
     "Invoke" SPACE invocable |
     "Execute" SPACE executable |
+    "Begin" |
     "Done" SPACE Value |
     "Skip" |
     "Fail" (SPACE Value)?

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -102,7 +102,7 @@ place_attribute := "^" Identifier | "^*"
 
 State :=
     "Start" SPACE uri |
-    "Pause" |
+    "Stop" |
     "Resume" |
     "Invoke" SPACE invocable |
     "Execute" SPACE executable |

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -106,6 +106,7 @@ State :=
     "Resume" |
     "Invoke" SPACE invocable |
     "Execute" SPACE executable |
+    "Return" SPACE Value |
     "Input" SPACE supplied |
     "Begin" |
     "Done" SPACE Value |

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -104,6 +104,7 @@ State :=
     "Start" SPACE uri |
     "Stop" |
     "Resume" |
+    "Finish" |
     "Invoke" SPACE invocable |
     "Execute" SPACE executable |
     "Return" SPACE Value |

--- a/pfftt.bnf
+++ b/pfftt.bnf
@@ -106,6 +106,7 @@ State :=
     "Resume" |
     "Invoke" SPACE invocable |
     "Execute" SPACE executable |
+    "Input" SPACE supplied |
     "Begin" |
     "Done" SPACE Value |
     "Skip" |
@@ -117,11 +118,35 @@ invocable := procedure | uri
 
 executable :=  Identifier "()"
 
-Value := unit | tablet
+; The values supplied to a procedure as parameters. Each value is shown
+; bound to its parameter name with `~` if one was declared, otherwise is
+; left bare when the parameter is unnamed.
+supplied := "(" ( " " binding ( ", " binding )* " " )? ")"
+binding := Value ( " ~ " Identifier )?
+
+Value := unit | literal | numeric | list | tuple | tablet
 
 unit := "()"
 
-; The Tablet data structure in Technique can nest arbitrarily but this runs
-; to end of line so any content here is acceptable.
+; A string literal — the form a chosen response or any text value records as.
+; Backslash escapes keep a value on a single record line: \" for a quote, \\
+; for a backslash, and \n / \r for the line breaks of a multi-line value.
+literal := "\"" literal_char* "\""
+literal_char := [^"\\] | "\\" ("\"" | "\\" | "n" | "r")
 
-tablet := "[" ANY "]"
+; An integer or a Quantity, written exactly as the Technique language number
+; literal it came from (integral and Quantity are defined in technique.bnf).
+numeric := integral | Quantity
+
+; An inline, comma-separated list of values. The empty list is "[]".
+list := "[]" | "[ " Value ( ", " Value )* " ]"
+
+; An inline, comma-separated tuple of values.
+tuple := "( " Value ( ", " Value )* " )"
+
+; A tablet: a series of "label" = value pairs, matching the Technique language
+; (the label is quoted). The empty tablet is "[=]", which distinguishes it from
+; the empty list. A bracketed value is a tablet when it carries a top-level
+; " = " and a list otherwise. Tablets, lists, and their values nest arbitrarily.
+tablet := "[=]" | "[ " pair ( ", " pair )* " ]"
+pair := "\"" literal_char* "\"" " = " Value

--- a/technique.bnf
+++ b/technique.bnf
@@ -100,7 +100,7 @@ Invocation := "<" invocation_target ">" ("(" arguments? ")")?
 
 invocation_target := local_target | external_target
 local_target := Identifier
-external_target := "https://" [a-zA-Z0-9.,?&#%=:/-_]+
+external_target := ("https" | "http" | "file") ":" [a-zA-Z0-9.,?&#%=:/-_]+
 
 ; A function call, usually to a built-in.
 Application := function_name "(" arguments? ")"


### PR DESCRIPTION
We define the Procedure interchange Format For Transferring Techniques, PFFTT, done in the same modified BNF style as the one for the Technique language.