### PR TITLE
Unify List and Tablet syntax

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -92,7 +92,7 @@ Expression :=
     foreach_keyword |
     repeat_keyword |
     expression_binding |
-    tablet
+    list_structure
 
 Invocation := "<" invocation_target ">" ("(" arguments? ")")?
 
@@ -169,7 +169,9 @@ Response := "'" response_value "'" response_condition?
 response_value := ANY
 response_condition :=  ANY
 
-tablet := "[" Pair (NEWLINE Pair)* "]"
+list_structure := "[" (list_element (list_separator list_element)*)? "]"
+list_element := Pair | Expression
+list_separator := ("," | NEWLINE)
 
 Pair := Label "=" Expression
 

--- a/technique.bnf
+++ b/technique.bnf
@@ -169,6 +169,9 @@ Response := "'" response_value "'" response_condition?
 response_value := ANY
 response_condition :=  ANY
 
+; Technique has lists (homogenous lists of values of a single type) and
+; tablets (a series of key/value pairs of "label" and an expression). Both are
+; delimited by brackets. Elements can be separated by commas or newlines.
 list_structure := "[" (list_element (list_separator list_element)*)? "]"
 list_element := Pair | Expression
 list_separator := ("," | NEWLINE)


### PR DESCRIPTION
We adjust the syntax of Technique to admit Lists. A List is a homogenous list of values of the same type. They use the same `[` ... `]` delimiters as Tablets do.

The Tablet remains a first-class concept in the language, but syntactically they present as a list of Pairs, where a Pair is a labelled value, denoted by the same current `"label" ~ value` syntax.