### PR TITLE
Add variable holes and type wildcards

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -53,16 +53,18 @@ procedure_declaration := Identifier parameters? ":" signature? NEWLINE
 Identifier := [a-z][a-z0-9_]*
 
 parameters := "(" variable ("," variable)* ")"
-variable := Identifier
+variable := Identifier | hole
+hole := "?"
 
 signature := Genus "->" Genus
 
-Genus := unit_genus | simple_genus | list_genus | tuple_genus | naked_genus
+Genus := unit_genus | simple_genus | list_genus | tuple_genus | naked_genus | wildcard
 unit_genus := "()"
 simple_genus := Forma
 list_genus := "[" Forma "]"
 tuple_genus := "(" Forma ("," Forma)+ ")"
 naked_genus := Forma ("," Forma)+
+wildcard := "*"
 
 Forma := [A-Z][a-zA-Z0-9_]*
 


### PR DESCRIPTION
We support having a bare invocation,

```
    <welcome_passengers>
```

even if the procedure is defined

```
welcome_passengers : Message -> Boarded
```

The compiler will allow this, putting an implicit placeholder "hole" value which can be resolved at runtime. The author can also specify a placeholder explicitly.

```
    <welcome_passengers>(?)
```

If holes are used explicitly then the arity of the invocation has to match that of the target procedure being invoked. Muliple `?` can be used in such a call

```
    <calculate_the_odds>(?, ?, ?)
```

for the case of three parameters.

We also add support for the related case of a procedure accepting any type, allowing a wildcard as a Genus,

```
pursuit_of_happiness : * -> Happiness
```
