### PR TITLE
Add unit literal

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -86,6 +86,7 @@ identifiers := Identifier | "(" Identifier ("," Identifier)* ")"
 
 Expression :=
     variable |
+    unit_literal |
     string_literal |
     multiline_literal |
     numeric_literal |
@@ -95,6 +96,8 @@ Expression :=
     repeat_keyword |
     expression_binding |
     list_structure
+
+unit_literal := "()"
 
 Invocation := "<" invocation_target ">" ("(" arguments? ")")?
 


### PR DESCRIPTION
While this is mostly only needed for completeness (as many constructions are already unit-valued, such as a prose-only step), we can nevernevertheless write literals for other values and _Unitus_ needs to be supported as well.