### PR TITLE
Add time constraints

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -76,7 +76,7 @@ procedure_description := Paragraph+
 
 Paragraph := Descriptive+ NEWLINE
 
-Descriptive := ANY | code_inline | descriptive_binding
+Descriptive := ANY | code_inline | descriptive_binding | cost_literal
 
 code_inline := "{" Expression "}"
 
@@ -96,6 +96,7 @@ Expression :=
     foreach_keyword |
     repeat_keyword |
     within_keyword |
+    cost_literal |
     expression_binding |
     list_structure |
     tuple_literal
@@ -119,6 +120,8 @@ foreach_keyword := "foreach" identifiers "in" Expression
 repeat_keyword := "repeat" Expression
 
 within_keyword := "within" Expression
+
+cost_literal := "$" "(" Expression ")"
 
 expression_binding := Expression "~" identifiers
 

--- a/technique.bnf
+++ b/technique.bnf
@@ -95,6 +95,7 @@ Expression :=
     Application |
     foreach_keyword |
     repeat_keyword |
+    within_keyword |
     expression_binding |
     list_structure |
     tuple_literal
@@ -116,6 +117,8 @@ arguments := Expression ("," Expression)*
 foreach_keyword := "foreach" identifiers "in" Expression
 
 repeat_keyword := "repeat" Expression
+
+within_keyword := "within" Expression
 
 expression_binding := Expression "~" identifiers
 


### PR DESCRIPTION
Introduce the `within` control structure keyword to specify a subscope that must be completed within the constraint of a resource budget. Appears as follows:

```technique
    4.  Roast turkey
        { within 2 hours }
            a.  Warm oven
            b.  Put bird in to cook
```

Add a new syntax for "cost literals", `$( ... )` for creating a new _Intratempse_ value. This can be written in descriptive prose (at the end of a step) to indicate the resource "cost" of a step, be it in time, currency, or some other amount.

```technique
            c.  Roast dinner $(3 hours)
```

This syntax is also available as a literal value constructor in an expression.

The argument of `within` is implicitly coerced to an _Intratempse_ if a bare _Quanticle_ literal is written there.