### PR TITLE
Refine definition of procedure declaration

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -187,7 +187,7 @@ response_condition :=  ANY
 ; Technique has lists (homogenous lists of values of a single type) and
 ; tablets (a series of key/value pairs of "label" and an expression). Both are
 ; delimited by brackets. Elements can be separated by commas or newlines.
-list_structure := "[" (list_element (list_separator list_element)*)? "]"
+list_structure := "[" list_element (list_separator list_element)* "]" | "[=]" | "[]"
 list_element := Pair | Expression
 list_separator := ("," | NEWLINE)
 

--- a/technique.bnf
+++ b/technique.bnf
@@ -48,7 +48,7 @@ Procedure :=
     procedure_description?
     Scope*
 
-procedure_declaration := Identifier parameters? ":" signature? NEWLINE
+procedure_declaration := Identifier parameters? " :" signature? NEWLINE
 
 Identifier := [a-z][a-z0-9_]*
 


### PR DESCRIPTION
Require space ` ` before colon `:` in procedure declarations. This allows us to cleanly differentiate a procedure declaration from common English prose in a procedure description or step content that happens to have a colon in it, for example, for explanation or when presenting a list.

Also fixes empty lists and empty tuples to be valid `list_structure` values.