### PR TITLE
Remove response conditions

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -180,9 +180,8 @@ role_attribute := "@" Identifier | "@*"
 place_attribute := "^" Identifier | "^*"
 
 response_block := Response ("|" Response)*
-Response := "'" response_value "'" response_condition?
+Response := "'" response_value "'"
 response_value := ANY
-response_condition :=  ANY
 
 ; Technique has lists (homogenous lists of values of a single type) and
 ; tablets (a series of key/value pairs of "label" and an expression). Both are


### PR DESCRIPTION
Although cute, having free-form text on lines with response literals was leading to considerable ambiguity the parser was having a hard time dealing with. We will remove the "conditions" from lines with responses.