### PR TITLE
Minimum required version in magic line

### DIFF
--- a/technique.bnf
+++ b/technique.bnf
@@ -30,7 +30,11 @@ Document := Metadata? Technique?
 ; what domain use case is intended when rendering this technique.
 Metadata := magic_line spdx_line? domain_line?
 
-magic_line := "%" "technique" "v1" NEWLINE
+magic_line := "%" "technique" Version NEWLINE
+Version := "v" major ("." minor ("." patch)?)?
+major := [0-9]+
+minor := [0-9]+
+patch := [0-9]+
 
 spdx_line := "!" license copyright? NEWLINE
 license := [a-zA-Z0-9.,-_ ()[]]+


### PR DESCRIPTION
Write the minimum required semantic version in the magic line in the headers of a Technique document.

So in addition to the original default of 

```technique
% technique v1
```
we can declare
```technique
% technique v1.3
```
to say that this document expects at least compiler version `1.3` and so crates `1.3.0`, `1.3.1`, `1.4` up to `<= 2.0` will all be able to read this document, but an older `0.7` or `1.2` will not.